### PR TITLE
Bump version to 0.0.11 and add type inference for schemas

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/schemas/auth.ts
+++ b/packages/client/src/schemas/auth.ts
@@ -26,3 +26,5 @@ export type MeResponse = BaseResponse<typeof meResponseSchema>;
 export type GoogleCallbackResponse = BaseResponse<
   typeof googleCallbackResponseSchema
 >;
+
+export type AuthMeType = z.infer<typeof meResponseSchema>;

--- a/packages/client/src/schemas/award.ts
+++ b/packages/client/src/schemas/award.ts
@@ -88,3 +88,7 @@ export type CompetitionListResponse = BaseResponse<
 export type CompetitionAwardListResponseSchema = BaseResponse<
   typeof competitionAwardSchema
 >;
+
+export type AwardType = z.infer<typeof awardSchema>;
+export type CompetitionType = z.infer<typeof competitionSchema>;
+export type CompetitionAwardType = z.infer<typeof competitionAwardSchema>;

--- a/packages/client/src/schemas/form.ts
+++ b/packages/client/src/schemas/form.ts
@@ -69,3 +69,6 @@ export const formApplicationFile = z.object({ presignedUrl: z.string() });
 export type CreateFormApplication = z.infer<typeof createFormApplicationSchema>;
 export type UpdateFormApplication = z.infer<typeof updateFormApplicationScheme>;
 export type FormApplicationFile = BaseResponse<typeof formApplicationFile>;
+
+export type FormDetailType = z.infer<typeof formDetailScheme>;
+export type FormResponseType = z.infer<typeof formResponseSchema>;

--- a/packages/client/src/schemas/member.ts
+++ b/packages/client/src/schemas/member.ts
@@ -83,3 +83,5 @@ export type MemberSkillResponse = BaseResponse<
 
 export const updateMemberSkillSchema = memberSkillSchema.partial();
 export type UpdateMemberSkill = z.infer<typeof updateMemberSkillSchema>;
+
+export type MemberType = z.infer<typeof memberSchema>;

--- a/packages/client/src/schemas/member.ts
+++ b/packages/client/src/schemas/member.ts
@@ -85,3 +85,5 @@ export const updateMemberSkillSchema = memberSkillSchema.partial();
 export type UpdateMemberSkill = z.infer<typeof updateMemberSkillSchema>;
 
 export type MemberType = z.infer<typeof memberSchema>;
+export type MemberLinkType = z.infer<typeof memberLinkSchema>;
+export type MemberSkillType = z.infer<typeof memberSkillSchema>;


### PR DESCRIPTION
Update the package version and introduce type inference for various schemas including AuthMe, Award, Competition, Form, and Member.