### PR TITLE
Rename fetchData to fetch for consistency in useDynamicFetch hook

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/hooks/use-dynamic-fetch.ts
+++ b/packages/client/src/hooks/use-dynamic-fetch.ts
@@ -14,7 +14,7 @@ function useDynamicFetch<TData, TParam>(
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
   const [isError, setIsError] = useState<boolean>(false);
 
-  const fetchData = useCallback(
+  const fetch = useCallback(
     async (opts: { param: TParam }) => {
       setIsPending(true);
       try {
@@ -44,7 +44,7 @@ function useDynamicFetch<TData, TParam>(
     [client, urlGenerator, config]
   );
 
-  return { fetchData, data, error, isPending, isSuccess, isError };
+  return { fetch, data, error, isPending, isSuccess, isError };
 }
 
 export default useDynamicFetch;


### PR DESCRIPTION
Update the `useDynamicFetch` hook to rename `fetchData` to `fetch` for improved consistency. Increment the version number to 0.0.25.