### PR TITLE
Update form ID references and add new type exports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/request/form-private.ts
+++ b/packages/client/src/request/form-private.ts
@@ -18,12 +18,12 @@ export const usePrivateFormList = () =>
 
 export const usePrivateForm = () =>
   useDynamicFetch<FormResponse, FormUUIDParam>(
-    ({ formUUID }) => `/admin/form/${formUUID}`
+    ({ formId }) => `/admin/form/${formId}`
   );
 
 export const usePrivateFormResponseList = () =>
   useDynamicFetch<FormDetailListResponse, FormUUIDParam>(
-    ({ formUUID }) => `/admin/form/${formUUID}/applications`
+    ({ formId }) => `/admin/form/${formId}/applications`
   );
 
 export const usePrivateFormApplication = () =>
@@ -34,31 +34,30 @@ export const usePrivateFormApplication = () =>
 export const usePrivateCreateForm = () =>
   useMutation<FormResponse, CreateFormRequest>(HttpMethod.POST, "/admin/form");
 
-// Updated dynamic hooks (no parameter on hook call; mutate receives parameter)
 export const usePrivateActivateForm = () => {
   return useDynamicMutation<FormResponse, FormUUIDParam>(
-    ({ formUUID }) => `/admin/form/${formUUID}/activate`,
+    ({ formId }) => `/admin/form/${formId}/activate`,
     HttpMethod.POST
   );
 };
 
 export const usePrivateDeactivateForm = () => {
   return useDynamicMutation<FormResponse, FormUUIDParam>(
-    ({ formUUID }) => `/admin/form/${formUUID}/deactivate`,
+    ({ formId }) => `/admin/form/${formId}/deactivate`,
     HttpMethod.POST
   );
 };
 
 export const usePrivateUpdateForm = () => {
   return useDynamicMutation<FormResponse, FormUUIDParam>(
-    ({ formUUID }) => `/admin/form/${formUUID}`,
+    ({ formId }) => `/admin/form/${formId}`,
     HttpMethod.PATCH
   );
 };
 
 export const usePrivateDeleteForm = () => {
   return useDynamicMutation<DeleteFormResponseType, FormUUIDParam>(
-    ({ formUUID }) => `/admin/form/${formUUID}`,
+    ({ formId }) => `/admin/form/${formId}`,
     HttpMethod.DELETE
   );
 };

--- a/packages/client/src/request/form.ts
+++ b/packages/client/src/request/form.ts
@@ -11,7 +11,7 @@ import {
 import useDynamicFetch from "@/hooks/use-dynamic-fetch";
 
 export type FormUUID = number;
-export type FormUUIDParam = { formUUID: FormUUID };
+export type FormUUIDParam = { formId: FormUUID };
 export type FormApplicationParam = { applicationUUID: number };
 
 // Read-only endpoints remain unchanged:
@@ -19,45 +19,45 @@ export const useFormListPublic = () => useFetch<FormListResponse>("/form");
 
 export const useFormApplication = () =>
   useDynamicFetch<FormResponse, FormUUIDParam>(
-    ({ formUUID }) => `/form/${formUUID}/application`
+    ({ formId }) => `/form/${formId}/application`
   );
 
 export const useFormApplicationFile = () =>
   useDynamicFetch<FormApplicationFileResponse, FormUUIDParam>(
-    ({ formUUID }) => `/form/${formUUID}/application/file`
+    ({ formId }) => `/form/${formId}/application/file`
   );
 
 export const useFormAccessibility = () =>
   useDynamicFetch<FormResponse, FormUUIDParam>(
-    ({ formUUID }) => `/form/${formUUID}/application/accessibility`
+    ({ formId }) => `/form/${formId}/application/accessibility`
   );
 
 export const useCreateFormApplication = () =>
   useDynamicMutation<FormResponse, FormUUIDParam, CreateFormApplicationRequest>(
-    ({ formUUID }) => `/form/${formUUID}/application`,
+    ({ formId }) => `/form/${formId}/application`,
     HttpMethod.POST
   );
 
 export const useUpdateFormApplication = () =>
   useDynamicMutation<FormResponse, FormUUIDParam, UpdateFormApplicationRequest>(
-    ({ formUUID }) => `/form/${formUUID}/application`,
+    ({ formId }) => `/form/${formId}/application`,
     HttpMethod.PATCH
   );
 
 export const useDeleteFormApplication = () =>
   useDynamicMutation<FormResponse, FormUUIDParam, unknown>(
-    ({ formUUID }) => `/form/${formUUID}/application`,
+    ({ formId }) => `/form/${formId}/application`,
     HttpMethod.DELETE
   );
 
 export const useUploadFormApplicationFile = () =>
   useDynamicMutation<unknown, FormUUIDParam, unknown>(
-    ({ formUUID }) => `/form/${formUUID}/application/file`,
+    ({ formId }) => `/form/${formId}/application/file`,
     HttpMethod.PATCH
   );
 
 export const useFormSubmit = () =>
   useDynamicMutation<FormResponse, FormUUIDParam, unknown>(
-    ({ formUUID }) => `/form/${formUUID}/application/submit`,
+    ({ formId }) => `/form/${formId}/application/submit`,
     HttpMethod.POST
   );

--- a/packages/client/src/schemas/auth.ts
+++ b/packages/client/src/schemas/auth.ts
@@ -1,20 +1,20 @@
-import { z } from 'zod';
-import { BaseResponse } from '@/schemas/base';
+import { z } from "zod";
+import { BaseResponse } from "@/schemas/base";
 
 export const refreshTokenResponseSchema = z.string();
 
 export const meResponseSchema = z.object({
-  id:    z.string(),
+  id: z.string(),
   email: z.string(),
-  name:  z.string(),
-  iat:   z.number(),
-  exp:   z.number(),
+  name: z.string(),
+  iat: z.number(),
+  exp: z.number(),
 });
 
 export const googleCallbackResponseSchema = z.object({
-  id:    z.string().optional(),
+  id: z.string().optional(),
   email: z.string(),
-  name:  z.string(),
+  name: z.string(),
 });
 
 export type RefreshTokenResponse = BaseResponse<
@@ -28,3 +28,17 @@ export type GoogleCallbackResponse = BaseResponse<
 >;
 
 export type AuthMeType = z.infer<typeof meResponseSchema>;
+
+// New exports for frontend props types (names ending with "Props" to avoid collision)
+export type RefreshTokenResponseSchemaProps = z.infer<
+  typeof refreshTokenResponseSchema
+>;
+export type MeResponseSchemaProps = z.infer<typeof meResponseSchema>;
+export type GoogleCallbackResponseSchemaProps = z.infer<
+  typeof googleCallbackResponseSchema
+>;
+
+// New exports for frontend types
+export type RefreshTokenData = z.infer<typeof refreshTokenResponseSchema>;
+export type MeData = z.infer<typeof meResponseSchema>;
+export type GoogleCallbackData = z.infer<typeof googleCallbackResponseSchema>;

--- a/packages/client/src/schemas/award.ts
+++ b/packages/client/src/schemas/award.ts
@@ -1,33 +1,35 @@
-import { z } from 'zod';
-import { BaseResponse } from '@/schemas/base';
+import { z } from "zod";
+import { BaseResponse } from "@/schemas/base";
 
 export const publicAwardSchema = z.object({
-  uuid:        z.string().uuid(),
-  fullTitle:   z.string(),
+  uuid: z.string().uuid(),
+  fullTitle: z.string(),
   memberNames: z.array(z.string()),
 });
 
 export const awardSchema = z.object({
-  uuid:            z.string().uuid(),
+  uuid: z.string().uuid(),
   competitionUUID: z.string().uuid(),
-  title:           z.string(),
-  grade:           z.number(),
-  gradeLabel:      z.string(),
-  rewardedAt:      z.string(),
-  createdAt:       z.string(),
-  updatedAt:       z.string(),
-  members:         z.array(z.object({
-    uuid:     z.string().uuid(),
-    name:     z.string(),
-    username: z.string(),
-  })),
+  title: z.string(),
+  grade: z.number(),
+  gradeLabel: z.string(),
+  rewardedAt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  members: z.array(
+    z.object({
+      uuid: z.string().uuid(),
+      name: z.string(),
+      username: z.string(),
+    })
+  ),
 });
 
 export const addAwardSchema = z.object({
-  title:       z.string(),
-  grade:       z.number(),
-  gradeLabel:  z.string(),
-  rewardedAt:  z.string().datetime(),
+  title: z.string(),
+  grade: z.number(),
+  gradeLabel: z.string(),
+  rewardedAt: z.string().datetime(),
   competition: z.object({
     uuid: z.string().uuid(),
     name: z.string(),
@@ -36,31 +38,33 @@ export const addAwardSchema = z.object({
 });
 
 export const competitionSchema = z.object({
-  uuid:      z.string().uuid(),
-  name:      z.string(),
+  uuid: z.string().uuid(),
+  name: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
 
 export const competitionAwardSchema = z.object({
-  uuid:            z.string().uuid(),
+  uuid: z.string().uuid(),
   competitionUUID: z.string().uuid(),
-  title:           z.string(),
-  grade:           z.number(),
-  gradeLabel:      z.string(),
-  rewardedAt:      z.string(),
-  createdAt:       z.string(),
-  updatedAt:       z.string(),
-  awards:          z.array(z.object({
-    uuid:            z.string().uuid(),
-    competitionUUID: z.string().uuid(),
-    title:           z.string(),
-    grade:           z.number(),
-    gradeLabel:      z.string(),
-    rewardedAt:      z.string(),
-    createdAt:       z.string(),
-    updatedAt:       z.string(),
-  })),
+  title: z.string(),
+  grade: z.number(),
+  gradeLabel: z.string(),
+  rewardedAt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  awards: z.array(
+    z.object({
+      uuid: z.string().uuid(),
+      competitionUUID: z.string().uuid(),
+      title: z.string(),
+      grade: z.number(),
+      gradeLabel: z.string(),
+      rewardedAt: z.string(),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+    })
+  ),
 });
 
 export const publicAwardListResponseSchema = z.array(publicAwardSchema);
@@ -72,11 +76,11 @@ export type PublicAwardListResponse = BaseResponse<
 export const awardListResponseSchema = z.array(awardSchema);
 export type AwardListResponse = BaseResponse<typeof awardListResponseSchema>;
 export type CreateAward = z.infer<typeof addAwardSchema>;
-export type CreateAwardWithoutUUID = Omit<CreateAward, 'uuid'>;
+export type CreateAwardWithoutUUID = Omit<CreateAward, "uuid">;
 
 export type CreateAwardMember = Pick<
   CreateAward,
-  'competition' | 'membersUUID'
+  "competition" | "membersUUID"
 >;
 
 export const competitionListResponseSchema = z.array(competitionSchema);
@@ -92,3 +96,27 @@ export type CompetitionAwardListResponseSchema = BaseResponse<
 export type AwardType = z.infer<typeof awardSchema>;
 export type CompetitionType = z.infer<typeof competitionSchema>;
 export type CompetitionAwardType = z.infer<typeof competitionAwardSchema>;
+
+// New exports for frontend props types
+export type PublicAwardSchemaProps = z.infer<typeof publicAwardSchema>;
+export type AwardSchemaProps = z.infer<typeof awardSchema>;
+export type AddAwardSchemaProps = z.infer<typeof addAwardSchema>;
+export type CompetitionSchemaProps = z.infer<typeof competitionSchema>;
+export type CompetitionAwardSchemaProps = z.infer<
+  typeof competitionAwardSchema
+>;
+export type PublicAwardListResponseSchemaProps = z.infer<
+  typeof publicAwardListResponseSchema
+>;
+export type AwardListResponseSchemaProps = z.infer<
+  typeof awardListResponseSchema
+>;
+
+// New exports for frontend types (using "Data" suffix or similar)
+export type PublicAwardData = z.infer<typeof publicAwardSchema>;
+export type AwardData = z.infer<typeof awardSchema>;
+export type AddAwardData = z.infer<typeof addAwardSchema>;
+export type CompetitionData = z.infer<typeof competitionSchema>;
+export type CompetitionAwardData = z.infer<typeof competitionAwardSchema>;
+export type PublicAwardListData = z.infer<typeof publicAwardListResponseSchema>;
+export type AwardListData = z.infer<typeof awardListResponseSchema>;

--- a/packages/client/src/schemas/form.ts
+++ b/packages/client/src/schemas/form.ts
@@ -78,3 +78,21 @@ export type UpdateFormApplicationRequest = z.infer<
 export type FormApplicationFileResponse = BaseResponse<
   typeof formApplicationFile
 >;
+
+// New exports for frontend types (using "Data" suffix)
+export type FormDetailData = z.infer<typeof formDetailScheme>;
+export type FormResponseData = z.infer<typeof formResponseSchema>;
+export type FormListResponseData = z.infer<typeof formListResponseSchema>;
+export type FormDetailListResponseData = z.infer<
+  typeof formDetailListResponseSchema
+>;
+export type CreateFormData = z.infer<typeof createFormSchema>;
+export type UpdateFormData = z.infer<typeof updateFormSchema>;
+export type DeleteFormData = z.infer<typeof deleteFormResponseSchema>;
+export type CreateFormApplicationData = z.infer<
+  typeof createFormApplicationSchema
+>;
+export type UpdateFormApplicationData = z.infer<
+  typeof updateFormApplicationSchema
+>;
+export type FormApplicationFileData = z.infer<typeof formApplicationFile>;


### PR DESCRIPTION
Refactor dynamic fetch hooks to use 'formId' for consistency and introduce new exports for frontend types and props in various schemas. Bump version to 0.0.27.