### PR TITLE
Update fetch hooks for improved state management

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/hooks/use-dynamic-fetch.ts
+++ b/packages/client/src/hooks/use-dynamic-fetch.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { AxiosRequestConfig } from "axios";
 import { ApiClient } from "@/client";
 import { HttpMethod } from "@/constants/http-method";
@@ -8,46 +8,55 @@ function useDynamicFetch<TData, TParam>(
   config?: AxiosRequestConfig
 ) {
   const client = new ApiClient();
+  // Display data - what the UI sees
   const [data, setData] = useState<TData | null>(null);
+  // Internal data - used for fresh fetches
+  const [internalData, setInternalData] = useState<TData | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [isPending, setIsPending] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
   const [isError, setIsError] = useState<boolean>(false);
   const cacheKey = useRef<string | null>(null);
 
+  // Update the display data whenever internal data changes
+  useEffect(() => {
+    if (internalData !== null) {
+      setData(internalData);
+    }
+  }, [internalData]);
+
   const fetch = useCallback(
     async (opts: { param: TParam; skipCache?: boolean }) => {
       setIsPending(true);
       const url = urlGenerator(opts.param);
       const newCacheKey = JSON.stringify({ url, config });
-      
-      // Skip cache가 true이거나 cacheKey가 변경된 경우에만 데이터를 요청
+
+      // Only update cache key when needed
       if (opts.skipCache || cacheKey.current !== newCacheKey) {
         cacheKey.current = newCacheKey;
       }
-      
+
       try {
         const response = await client.request<TData>({
           method: HttpMethod.GET,
           url,
           ...config,
-          // Skip cache가 true일 경우에만 캐시를 사용하지 않음
-          ...(opts.skipCache && { 
-            params: { 
-              ...config?.params, 
-              _t: new Date().getTime() 
-            } 
+          // Add cache-busting parameter when skipCache is true
+          ...(opts.skipCache && {
+            params: {
+              ...config?.params,
+              _t: new Date().getTime(),
+            },
           }),
         });
-        setData(response);
+
+        // Update internal data first
+        setInternalData(response);
         setIsSuccess(true);
         setIsError(false);
         return response;
       } catch (err) {
-        console.error(
-          `[dynamic fetch](${url}) Error:`,
-          err
-        );
+        console.error(`[dynamic fetch](${url}) Error:`, err);
         setError(err as Error);
         setIsError(true);
         setIsSuccess(false);
@@ -59,14 +68,14 @@ function useDynamicFetch<TData, TParam>(
     [client, urlGenerator, config]
   );
 
-  const refresh = useCallback(
+  const refetch = useCallback(
     async (param: TParam) => {
       return fetch({ param, skipCache: true });
     },
     [fetch]
   );
 
-  return { fetch, refresh, data, error, isPending, isSuccess, isError };
+  return { fetch, refetch, data, error, isPending, isSuccess, isError };
 }
 
 export default useDynamicFetch;

--- a/packages/client/src/hooks/use-fetch.ts
+++ b/packages/client/src/hooks/use-fetch.ts
@@ -3,13 +3,16 @@ import { apiRequest } from "@/request";
 import { UseFetchResult } from "@/types/hooks/fetch";
 import { ApiUrl } from "@/url";
 import { AxiosRequestConfig } from "axios";
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 
 export const useFetch = <TData>(
   url: string,
   config?: AxiosRequestConfig
 ): UseFetchResult<TData> => {
+  // Display data - what the UI sees
   const [data, setData] = useState<TData | null>(null);
+  // Internal data - used for fresh fetches
+  const [internalData, setInternalData] = useState<TData | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [isPending, setIsPending] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
@@ -17,7 +20,13 @@ export const useFetch = <TData>(
   const cacheKey = useRef<string | null>(null);
   const requestUrl = ApiUrl(url);
 
-  // Alternative solution (if you can't change the interface)
+  // Update the display data whenever internal data changes
+  useEffect(() => {
+    if (internalData !== null) {
+      setData(internalData);
+    }
+  }, [internalData]);
+
   const fetch = useCallback(
     async (options?: { skipCache?: boolean }) => {
       setIsPending(true);
@@ -26,6 +35,7 @@ export const useFetch = <TData>(
       // Skip cache가 true이거나 cacheKey가 변경된 경우에만 데이터를 요청
       if (options?.skipCache || cacheKey.current !== newCacheKey) {
         cacheKey.current = newCacheKey;
+        // We'll update internalData but not data yet
       }
 
       try {
@@ -41,10 +51,10 @@ export const useFetch = <TData>(
           }),
         });
 
-        setData(response);
+        // Update internal data first
+        setInternalData(response);
         setIsSuccess(true);
         setIsError(false);
-        // Don't return the response
       } catch (err) {
         console.error(`[fetch](${url}) API Fetching hooks Error:`, err);
         setError(err as Error);
@@ -58,13 +68,13 @@ export const useFetch = <TData>(
     [requestUrl, config]
   );
 
-  const refresh = useCallback(async () => {
+  const refetch = useCallback(async () => {
     return fetch({ skipCache: true });
   }, [fetch]);
 
   return {
     fetch,
-    refresh,
+    refetch,
     data,
     error,
     isPending,

--- a/packages/client/src/types/hooks/fetch.ts
+++ b/packages/client/src/types/hooks/fetch.ts
@@ -1,6 +1,6 @@
 export interface UseFetchResult<TData> {
   fetch:     () => Promise<void>;
-  refresh:   () => Promise<void>;
+  refetch:   () => Promise<void>;
   data:      TData | null;
   error:     Error | null;
   isPending: boolean;


### PR DESCRIPTION
Refactor `useDynamicFetch` and `useFetch` hooks to utilize internal data for state management and rename the `refresh` function to `refetch`. This change enhances data handling and ensures the UI reflects the latest state more effectively.