### PR TITLE
Remove unused types and refactor award schema for clarity

### DIFF
--- a/packages/client/src/request/form-private.ts
+++ b/packages/client/src/request/form-private.ts
@@ -5,7 +5,6 @@ import { useMutation } from "@/hooks/use-mutation";
 import useDynamicMutation from "@/hooks/use-dynamic-mutation";
 import {
   CreateFormRequest,
-  DeleteFormResponseType,
   FormDetailListResponse,
   FormDetailResponse,
   FormListResponse,
@@ -56,7 +55,7 @@ export const usePrivateUpdateForm = () => {
 };
 
 export const usePrivateDeleteForm = () => {
-  return useDynamicMutation<DeleteFormResponseType, FormUUIDParam>(
+  return useDynamicMutation<unknown, FormUUIDParam>(
     ({ formId }) => `/admin/form/${formId}`,
     HttpMethod.DELETE
   );

--- a/packages/client/src/schemas/award.ts
+++ b/packages/client/src/schemas/award.ts
@@ -94,29 +94,7 @@ export type CompetitionAwardListResponseSchema = BaseResponse<
 >;
 
 export type AwardType = z.infer<typeof awardSchema>;
-export type CompetitionType = z.infer<typeof competitionSchema>;
 export type CompetitionAwardType = z.infer<typeof competitionAwardSchema>;
 
-// New exports for frontend props types
-export type PublicAwardSchemaProps = z.infer<typeof publicAwardSchema>;
-export type AwardSchemaProps = z.infer<typeof awardSchema>;
-export type AddAwardSchemaProps = z.infer<typeof addAwardSchema>;
-export type CompetitionSchemaProps = z.infer<typeof competitionSchema>;
-export type CompetitionAwardSchemaProps = z.infer<
-  typeof competitionAwardSchema
->;
-export type PublicAwardListResponseSchemaProps = z.infer<
-  typeof publicAwardListResponseSchema
->;
-export type AwardListResponseSchemaProps = z.infer<
-  typeof awardListResponseSchema
->;
-
-// New exports for frontend types (using "Data" suffix or similar)
-export type PublicAwardData = z.infer<typeof publicAwardSchema>;
-export type AwardData = z.infer<typeof awardSchema>;
-export type AddAwardData = z.infer<typeof addAwardSchema>;
-export type CompetitionData = z.infer<typeof competitionSchema>;
-export type CompetitionAwardData = z.infer<typeof competitionAwardSchema>;
-export type PublicAwardListData = z.infer<typeof publicAwardListResponseSchema>;
-export type AwardListData = z.infer<typeof awardListResponseSchema>;
+export type PublicAwardType = z.infer<typeof publicAwardSchema>;
+export type CreateAwardType = z.infer<typeof addAwardSchema>;

--- a/packages/client/src/schemas/form.ts
+++ b/packages/client/src/schemas/form.ts
@@ -40,7 +40,6 @@ export const formListResponseSchema = z.array(formResponseSchema);
 export const formDetailListResponseSchema = z.array(formDetailScheme);
 export const createFormSchema = formResponseSchema.omit({ id: true });
 export const updateFormSchema = formResponseSchema.omit({ id: true }).partial();
-export const deleteFormResponseSchema = z.object({});
 
 // Type exports for Form API with consistent naming
 export type FormDetailResponse = BaseResponse<typeof formDetailScheme>;
@@ -51,9 +50,6 @@ export type FormDetailListResponse = BaseResponse<
 >;
 export type CreateFormRequest = z.infer<typeof createFormSchema>;
 export type UpdateFormRequest = z.infer<typeof updateFormSchema>;
-export type DeleteFormResponseType = BaseResponse<
-  typeof deleteFormResponseSchema
->;
 
 // Public Form API Schemas
 export const createFormApplicationSchema = formDetailScheme.pick({
@@ -80,15 +76,11 @@ export type FormApplicationFileResponse = BaseResponse<
 >;
 
 // New exports for frontend types (using "Data" suffix)
-export type FormApplicationResponseType = z.infer<typeof formDetailScheme>;
-export type FormResponseType = z.infer<typeof formResponseSchema>;
-export type FormListResponseType = z.infer<typeof formListResponseSchema>;
-export type FormDetailListResponseType = z.infer<
-  typeof formDetailListResponseSchema
->;
+export type FormApplicationType = z.infer<typeof formDetailScheme>;
+export type FormType = z.infer<typeof formResponseSchema>;
+
 export type CreateFormType = z.infer<typeof createFormSchema>;
 export type UpdateFormType = z.infer<typeof updateFormSchema>;
-export type DeleteFormType = z.infer<typeof deleteFormResponseSchema>;
 export type CreateFormApplicationType = z.infer<
   typeof createFormApplicationSchema
 >;


### PR DESCRIPTION
Eliminate the `DeleteFormResponseType` for consistency and improve naming conventions in award schema types.