### PR TITLE
Bump version to 0.1.12 and update response types for consistency

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/request/form/private.ts
+++ b/packages/client/src/request/form/private.ts
@@ -2,7 +2,7 @@ import { HttpMethod } from "@/constants/http-method"
 import useDynamicMutation from "@/hooks/use-dynamic-mutation"
 import { useFetch } from "@/hooks/use-fetch"
 import { useMutation } from "@/hooks/use-mutation"
-import { DeleteFormApplicationResponse, FormApplicationResponse, FormListResponse, FormResponse, UpdateFormApplicationRequest } from "@/schemas/form"
+import { DeleteFormApplicationResponse, FormApplicationListResponse, FormApplicationListType, FormApplicationResponse, FormListResponse, FormResponse, UpdateFormApplicationRequest } from "@/schemas/form"
 import { FormIDParam } from "./public"
 import useDynamicFetch from "@/hooks/use-dynamic-fetch"
 
@@ -71,7 +71,7 @@ export const usePrivateForm = () => {
  * @returns {FormListResponse} FormListResponse
  */
 export const usePrivateFormApplicationList = () => {
-    return useDynamicFetch<FormListResponse, FormIDParam>(
+    return useDynamicFetch<FormApplicationListResponse, FormIDParam>(
         ({ formId }) => `/admin/form/${formId}/applications`
     )
 }

--- a/packages/client/src/schemas/form.ts
+++ b/packages/client/src/schemas/form.ts
@@ -69,7 +69,7 @@ export type FormApplicationType = z.infer<typeof formApplicationSchema>;
 
 // Form Application List
 export const FormApplicationListResponseSchema = z.array(formApplicationSchema);
-export type FormDetailListResponse = BaseResponse<
+export type FormApplicationListResponse = BaseResponse<
   typeof FormApplicationListResponseSchema
 >;
 export type FormApplicationListType = z.infer<


### PR DESCRIPTION
Update the version number and ensure response types in `usePrivateFormApplicationList` are consistent with the new schema.