### PR TITLE
Uncomment redirect on refresh token failure in ApiClient

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -49,7 +49,7 @@ export class ApiClient {
             }
           } catch (refreshError) {
             console.error('Refresh token request failed:', refreshError);
-            // window.location.href = `${this.authURL}?service=${this.service}`;
+            window.location.href = `${this.authURL}?service=${this.service}`;
           }
 
           this.isRefreshing = false;


### PR DESCRIPTION
Restore the redirect functionality for handling refresh token failures in the ApiClient. Update the version to 0.1.20.