### PR TITLE
Increase API timeout to 30 seconds in ApiClient

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -17,7 +17,7 @@ export class ApiClient {
 
     this.instance = axios.create({
       baseURL: baseURL.toString(),
-      timeout: Number(process.env.API_TIMEOUT) || 5000,
+      timeout: 30000,
       withCredentials: true,
     });
 


### PR DESCRIPTION
Update the API client to increase the timeout setting from 5 seconds to 30 seconds for improved reliability. Update the version number accordingly.