### PR TITLE
Bump version to 0.1.22 and increase API timeout

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tapie-kr/api-client",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Type-safe API client for TAPIE API",
   "license": "MIT",
   "repository": {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -17,7 +17,7 @@ export class ApiClient {
 
     this.instance = axios.create({
       baseURL: baseURL.toString(),
-      timeout: 30000,
+      timeout: 100000000000,
       withCredentials: true,
     });
 


### PR DESCRIPTION
Update the version of the API client and significantly extend the API timeout for improved reliability.